### PR TITLE
Fix unspecified issue

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -26,8 +26,8 @@ from .bicycle_sale import BicycleSale, SalePaymentMethod
 
 # HR models
 from .hr_leave import (
-    LeaveType, LeaveRequest, LeaveBalance, LeaveQuota,
-    LeaveRequestStatus
+    LeaveType, LeaveApplication, LeaveBalance,
+    LeaveStatus
 )
 from .hr_attendance import (
     AttendanceRecord, AttendanceStatus, AttendanceIssue
@@ -81,10 +81,9 @@ __all__ = [
     "SalePaymentMethod",
     # HR
     "LeaveType",
-    "LeaveRequest",
+    "LeaveApplication",
     "LeaveBalance",
-    "LeaveQuota",
-    "LeaveRequestStatus",
+    "LeaveStatus",
     "AttendanceRecord",
     "AttendanceStatus",
     "AttendanceIssue",


### PR DESCRIPTION
Fixed ImportError in backend/app/models/__init__.py by correcting the class names to match the actual definitions in hr_leave.py:
- Changed LeaveRequest to LeaveApplication
- Changed LeaveRequestStatus to LeaveStatus
- Removed LeaveQuota (not yet implemented)

This resolves the "cannot import name 'LeaveRequest'" error that prevented the backend from starting.